### PR TITLE
Feature/landscape

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -18,10 +18,15 @@ public class LightboxController: UIViewController {
   var images = [String]()
 
   var collectionSize = CGSizeZero
+  var pageLabelBottom: NSLayoutConstraint?
 
   lazy var config: Config = {
     return LightboxConfig.sharedInstance.config
   }()
+
+  var pageLabelBottomConstant: CGFloat {
+    return collectionSize.width < collectionSize.height ? -20 : -2
+  }
 
   var rotating = false
 
@@ -165,9 +170,10 @@ public class LightboxController: UIViewController {
       relatedBy: .Equal, toItem: view, attribute: .Trailing,
       multiplier: 1, constant: 0))
 
-    view.addConstraint(NSLayoutConstraint(item: pageLabel, attribute: .Bottom,
+    pageLabelBottom = NSLayoutConstraint(item: pageLabel, attribute: .Bottom,
       relatedBy: .Equal, toItem: view, attribute: .Bottom,
-      multiplier: 1, constant: -20))
+      multiplier: 1, constant: pageLabelBottomConstant)
+    view.addConstraint(pageLabelBottom!)
     
     view.addConstraint(NSLayoutConstraint(item: closeButton, attribute: .Top,
       relatedBy: .Equal, toItem: view, attribute: .Top,
@@ -197,19 +203,19 @@ public class LightboxController: UIViewController {
   }
 
   public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-    println("BLO")
     rotating = true
     collectionSize = size
     collectionView.collectionViewLayout.invalidateLayout()
 
     coordinator.animateAlongsideTransition({ _ in
       self.collectionView.collectionViewLayout.invalidateLayout()
+      self.pageLabelBottom?.constant = self.pageLabelBottomConstant
       }, completion: { _ in
         let indexPath = NSIndexPath(forItem: self.page, inSection: 0)
         self.view.layoutIfNeeded()
         self.collectionView.scrollToItemAtIndexPath(indexPath,
-          atScrollPosition:UICollectionViewScrollPosition.CenteredHorizontally,
-          animated:false)
+          atScrollPosition: .CenteredHorizontally,
+          animated: false)
         self.rotating = false
     });
   }
@@ -221,7 +227,6 @@ public class LightboxController: UIViewController {
       var offset = collectionView.contentOffset
 
       offset.x = CGFloat(page) * collectionSize.width
-
       collectionView.setContentOffset(offset, animated: animated)
     }
   }

--- a/Source/LightboxViewCell.swift
+++ b/Source/LightboxViewCell.swift
@@ -4,10 +4,43 @@ public class LightboxViewCell: UICollectionViewCell {
 
   public static let reuseIdentifier: String = "LightboxViewCell"
 
+  var constraintsAdded = false
+
   public lazy var lightboxView: LightboxView = { [unowned self] in
     let lightboxView = LightboxView(frame: self.bounds)
+    lightboxView.setTranslatesAutoresizingMaskIntoConstraints(false)
+
     self.contentView.addSubview(lightboxView)
 
     return lightboxView
   }()
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+
+    setupConstraints()
+    lightboxView.updateViewLayout()
+  }
+
+  private func setupConstraints() {
+    if !constraintsAdded {
+      addConstraint(NSLayoutConstraint(item: lightboxView, attribute: .Leading,
+        relatedBy: .Equal, toItem: contentView, attribute: .Leading,
+        multiplier: 1, constant: 0))
+
+      addConstraint(NSLayoutConstraint(item: lightboxView, attribute: .Trailing,
+        relatedBy: .Equal, toItem: contentView, attribute: .Trailing,
+        multiplier: 1, constant: 0))
+
+      addConstraint(NSLayoutConstraint(item: lightboxView, attribute: .Top,
+        relatedBy: .Equal, toItem: contentView, attribute: .Top,
+        multiplier: 1, constant: 0))
+
+      addConstraint(NSLayoutConstraint(item: lightboxView, attribute: .Bottom,
+        relatedBy: .Equal, toItem: contentView, attribute: .Bottom,
+        multiplier: 1, constant: 0))
+
+      constraintsAdded = true
+    }
+  }
 }


### PR DESCRIPTION
@zenangst @RamonGilabert 
Took another step on this and now it magically works like expected:
1. Support all orientations.
2. Show the correct page after orientation change (with or without zoom).

Animation during orientation change might be not perfect, but it's another thing to improve :smiley: 

Should fix: https://github.com/hyperoslo/Lightbox/issues/3

![ios simulator screen shot 13 jul 2015 21 49 51](https://cloud.githubusercontent.com/assets/10529867/8659240/a19d427e-29a9-11e5-871d-b53a3a22bf80.png)