### PR TITLE
Return empty array when user deleted all the photos

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -395,10 +395,8 @@ public class LightboxController: UIViewController {
       indexPath = NSIndexPath(forRow: page - 1, inSection: 0)
     } else {
       array.removeObjectAtIndex(index)
-      dismissalDelegate?.lightboxControllerDidDismiss(self)
-      dismissViewControllerAnimated(true, completion: nil)
       images = array
-      collectionView.reloadData()
+      dismissalDelegate?.lightboxControllerDidDismiss(self)
     }
 
     if images.count != 0 {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -394,7 +394,9 @@ public class LightboxController: UIViewController {
     } else if page == images.count - 1 && images.count != 1 {
       indexPath = NSIndexPath(forRow: page - 1, inSection: 0)
     } else {
-      array.removeObjectAtIndex(index)
+      if array.count != 0 {
+        array.removeObjectAtIndex(index)
+      }
       images = array
       dismissalDelegate?.lightboxControllerDidDismiss(self)
     }


### PR DESCRIPTION
There was a bug: if user deleted all the photos from Lightbox, it still stored an array that contained the last photo.  So, if you tried to get an edited set of photos (if all of them had been removed) - you still get one "unremovable" photo.

The problem was in improper method ordering.