### PR TITLE
Fix crash when removing images fast

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -399,6 +399,8 @@ public class LightboxController: UIViewController {
       }
       images = array
       dismissalDelegate?.lightboxControllerDidDismiss(self)
+      collectionView.reloadData()
+      return
     }
 
     if images.count != 0 {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -385,6 +385,7 @@ public class LightboxController: UIViewController {
   }
 
   func deleteButtonDidPress(button: UIButton) {
+    button.enabled = false
     var indexPath = NSIndexPath()
     let index = page
     let array = images.mutableCopy() as! NSMutableArray
@@ -399,8 +400,6 @@ public class LightboxController: UIViewController {
       }
       images = array
       dismissalDelegate?.lightboxControllerDidDismiss(self)
-      collectionView.reloadData()
-      return
     }
 
     if images.count != 0 {
@@ -413,6 +412,7 @@ public class LightboxController: UIViewController {
         self.images = array
         self.page = index
         self.collectionView.reloadData()
+        button.enabled = true
       }
     }
   }


### PR DESCRIPTION
Disabling button while removing the items fixes the issue when collectionView still has been scrolling to the item which is already deleted by second tap.