### PR TITLE
Add page index check being out of bounds

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -47,9 +47,7 @@ public class LightboxController: UIViewController {
 
   public private(set) var page = 0 {
     didSet {
-      var result = max(0, page)
-      result = min(images.count - 1, result)
-      page = result
+      page = min(images.count - 1, max(0, page))
 
       let text = "\(page + 1)/\(images.count)"
 

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -47,8 +47,12 @@ public class LightboxController: UIViewController {
 
   public private(set) var page = 0 {
     didSet {
+      var result = max(0, page)
+      result = min(images.count - 1, result)
+      page = result
+
       let text = "\(page + 1)/\(images.count)"
-      
+
       pageLabel.attributedText = NSAttributedString(string: text,
         attributes: config.pageIndicator.textAttributes)
       pageLabel.sizeToFit()


### PR DESCRIPTION
Lightbox crashed few times because of page index being out of bounds. In rotation code colllectionView method `scrollToItemAtIndexPath` was called and caused a crash. I've constrained pageIndex to never be less than zero or greater than amount of images in LightBox.
Tested on device.
