### PR TITLE
Improve rotation

### DIFF
--- a/Demos/DemoLightbox/DemoLightbox/ViewController.swift
+++ b/Demos/DemoLightbox/DemoLightbox/ViewController.swift
@@ -10,6 +10,7 @@ class ViewController: UIViewController {
     button.setTitleColor(UIColor(red:0.47, green:0.6, blue:0.13, alpha:1), forState: .Normal)
     button.titleLabel?.font = UIFont(name: "AvenirNextCondensed-DemiBold", size: 30)
     button.frame = UIScreen.mainScreen().bounds
+    button.autoresizingMask = [.FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleBottomMargin]
 
     return button
     }()
@@ -17,6 +18,7 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    view.autoresizingMask = [.FlexibleTopMargin, .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleBottomMargin]
     view.backgroundColor = UIColor.whiteColor()
     view.addSubview(showButton)
   }

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -193,7 +193,9 @@ public class LightboxController: UIViewController {
   override public func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
-    configureLayout(size)
+    coordinator.animateAlongsideTransition({ (UIViewControllerTransitionCoordinatorContext) -> Void in
+      self.configureLayout(size)
+      }, completion: nil)
   }
 
   // MARK: - Pagination


### PR DESCRIPTION
This PR improves the rotating transition. It uses the `UIViewControllerTransitionCoordinator` in `viewWillTransitionToSize` to animate the resizing of `pageViews`.


```swift
  override public func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)

    coordinator.animateAlongsideTransition({ (UIViewControllerTransitionCoordinatorContext) -> Void in
      self.configureLayout(size)
      }, completion: nil)
  }
```

It looks like this;

![lightbox-rotation](https://cloud.githubusercontent.com/assets/57446/12702401/520477a0-c828-11e5-9d59-c9ba6531faea.gif)
