### PR TITLE
Fix typo in delegate method

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -294,7 +294,7 @@ extension LightboxController: UIScrollViewDelegate {
 
 extension LightboxController: PageViewDelegate {
 
-  func pageVewDidZoom(pageView: PageView) {
+  func pageViewDidZoom(pageView: PageView) {
     let hidden = pageView.zoomScale != 1.0
     let duration = hidden ? 0.1 : 1.0
     let alpha: CGFloat = hidden ? 0.0 : 1.0

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 protocol PageViewDelegate: class {
 
-  func pageVewDidZoom(pageView: PageView)
+  func pageViewDidZoom(pageView: PageView)
 }
 
 class PageView: UIScrollView {
@@ -144,6 +144,6 @@ extension PageView: UIScrollViewDelegate {
 
   func scrollViewDidZoom(scrollView: UIScrollView) {
     centerImageView()
-    pageViewDelegate?.pageVewDidZoom(self)
+    pageViewDelegate?.pageViewDidZoom(self)
   }
 }


### PR DESCRIPTION
Found a typo in the `PageViewDelegate`.

`pageVewDidZoom` -> `pageViewDidZoom`