### PR TITLE
Call dismissalDelegate in finishInteractiveTransition

### DIFF
--- a/Source/Library/LightboxTransition.swift
+++ b/Source/Library/LightboxTransition.swift
@@ -95,6 +95,9 @@ public class LightboxTransition: UIPercentDrivenInteractiveTransition {
 
   public override func finishInteractiveTransition() {
     super.finishInteractiveTransition()
+
+    guard let lightboxController = lightboxController else { return }
+    lightboxController.dismissalDelegate?.lightboxControllerWillDismiss(lightboxController)
   }
 }
 


### PR DESCRIPTION
Before, the dismissal delegate was not called when you swipe the image of screen, this PR fixes that issue.