### PR TITLE
Fix dynamic background for remote images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 
 before_install:
 - brew update
-- brew install carthage
+#- brew install carthage
 - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 - carthage update --platform iOS
 

--- a/Demos/DemoLightbox/DemoLightbox/Info.plist
+++ b/Demos/DemoLightbox/DemoLightbox/Info.plist
@@ -36,5 +36,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAllowsArbitraryLoads</key>
+	<true/>
 </dict>
 </plist>

--- a/Demos/DemoLightbox/DemoLightbox/ViewController.swift
+++ b/Demos/DemoLightbox/DemoLightbox/ViewController.swift
@@ -38,7 +38,8 @@ class ViewController: UIViewController {
       LightboxImage(
         image: UIImage(named: "photo3")!,
         text: "Some very long lorem ipsum text."
-      )
+      ),
+      LightboxImage(imageURL: NSURL(string: "https://cdn.arstechnica.net/2011/10/05/iphone4s_sample_apple-4e8c706-intro.jpg")!)
     ]
 
     let controller = LightboxController(images: images)

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -3,7 +3,7 @@ import Hue
 
 public class LightboxConfig {
 
-  public typealias LoadImageCompletion = (error: NSError?) -> Void
+  public typealias LoadImageCompletion = (error: NSError?, image: UIImage?) -> Void
 
   public static var hideStatusBar = true
 
@@ -18,7 +18,7 @@ public class LightboxConfig {
           imageView.image = image
         }
 
-        completion?(error: error)
+        completion?(error: error, image: imageView.image)
     })
   }
 

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -95,7 +95,7 @@ public class LightboxController: UIViewController {
 
       pageDelegate?.lightboxController(self, didMoveToPage: currentPage)
 
-      if let image = images[currentPage].image where dynamicBackground {
+      if let image = pageViews[currentPage].imageView.image where dynamicBackground {
         delay(0.125) {
           self.loadDynamicBackground(image)
         }

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -97,8 +97,7 @@ public class LightboxController: UIViewController {
 
       if let image = images[currentPage].image where dynamicBackground {
         delay(0.125) {
-          self.backgroundView.image = image
-          self.backgroundView.layer.addAnimation(CATransition(), forKey: kCATransitionFade)
+          self.loadDynamicBackground(image)
         }
       }
     }
@@ -284,6 +283,11 @@ public class LightboxController: UIViewController {
 
     overlayView.frame = scrollView.frame
     overlayView.resizeGradientLayer()
+  }
+
+  private func loadDynamicBackground(image: UIImage) {
+    backgroundView.image = image
+    backgroundView.layer.addAnimation(CATransition(), forKey: kCATransitionFade)
   }
 }
 

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -322,6 +322,12 @@ extension LightboxController: UIScrollViewDelegate {
 
 extension LightboxController: PageViewDelegate {
 
+  func remoteImageDidLoad(image: UIImage?) {
+    if let image = image where dynamicBackground {
+      loadDynamicBackground(image)
+    }
+  }
+
   func pageViewDidZoom(pageView: PageView) {
     let hidden = pageView.zoomScale != 1.0
     let duration = hidden ? 0.1 : 1.0

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -323,9 +323,8 @@ extension LightboxController: UIScrollViewDelegate {
 extension LightboxController: PageViewDelegate {
 
   func remoteImageDidLoad(image: UIImage?) {
-    if let image = image where dynamicBackground {
-      loadDynamicBackground(image)
-    }
+    guard let image = image where dynamicBackground else { return }
+    loadDynamicBackground(image)
   }
 
   func pageViewDidZoom(pageView: PageView) {

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -18,12 +18,12 @@ public class LightboxImage {
     self.text = text
   }
 
-  public func addImageTo(imageView: UIImageView, completion: (() -> Void)? = nil) {
+  public func addImageTo(imageView: UIImageView, completion: ((image: UIImage?) -> Void)? = nil) {
     if let image = image {
       imageView.image = image
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView: imageView, URL: imageURL) { error in
-        completion?()
+      LightboxConfig.loadImage(imageView: imageView, URL: imageURL) { error, image in
+        completion?(image: image)
       }
     }
   }

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -3,6 +3,7 @@ import UIKit
 protocol PageViewDelegate: class {
 
   func pageViewDidZoom(pageView: PageView)
+  func remoteImageDidLoad(image: UIImage?)
 }
 
 class PageView: UIScrollView {

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -27,9 +27,10 @@ class PageView: UIScrollView {
     self.image = image
     super.init(frame: CGRectZero)
 
-    image.addImageTo(imageView) {
+    image.addImageTo(imageView) { image in
       self.userInteractionEnabled = true
       self.configureImageView()
+      self.pageViewDelegate?.remoteImageDidLoad(image)
     }
 
     configure()


### PR DESCRIPTION
Dynamic background didn’t work with remote images. This PR fixes that issue.

Had to add another method on `PageViewDelegate` called `remoteImageDidLoad`.
This method takes an optional image and is invoked when the remote image has loaded.

`LightboxController` conforms to `PageViewDelegate` and will update the background as soon as the network request returns an image.

The demo has also been updated to allow and display a remote image.

![simulator screen shot feb 10 2016 08 50 37](https://cloud.githubusercontent.com/assets/57446/12941532/b31d6f3a-cfd3-11e5-905b-41e0d5e6203f.png)
