### PR TITLE
Fix crash when compiling in release mode

### DIFF
--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -27,7 +27,7 @@ class PageView: UIScrollView {
     self.image = image
     super.init(frame: CGRectZero)
 
-    image.addImageTo(imageView) { image in
+    self.image.addImageTo(imageView) { image in
       self.userInteractionEnabled = true
       self.configureImageView()
       self.pageViewDelegate?.remoteImageDidLoad(image)


### PR DESCRIPTION
Apparently, not using `self` here caused the application to crash when running it in release mode.