### PR TITLE
Making var private

### DIFF
--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -2,8 +2,8 @@ import UIKit
 
 public class LightboxImage {
 
-  public var image: UIImage?
-  public var imageURL: NSURL?
+  private var image: UIImage?
+  private var imageURL: NSURL?
   public var text: String
 
   // MARK: - Initialization


### PR DESCRIPTION
I think these should be private. 

Consider the following use case 

```swift 
let lightBoxImage = LightboxImage(imageURL: NSURL(string: "https://cdn.arstechnica.net/2011/10/05/iphone4s_sample_apple-4e8c706-intro.jpg")!)
lightBoxImage.image  = UIImage(named: "photo1")!
lightBoxImage.addImageTo(imageView)
```

Now the implementation of `addImageTo` suggests that `imageURL` and `image` are mutually exclusive. 