### PR TITLE
Removing dependency on Hue

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "hyperoslo/Hue" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "hyperoslo/Hue" "f82ffc7dd55d093d3acc6ce5b3d36ca259091fdd"

--- a/Demos/DemoLightbox/Podfile.lock
+++ b/Demos/DemoLightbox/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
-  - Hue (2.0.1)
-  - Lightbox (1.0.0):
-    - Hue
-    - Sugar
-  - Sugar (3.0.0)
+  - Lightbox (1.0.0)
 
 DEPENDENCIES:
   - Lightbox (from `../../`)
 
 EXTERNAL SOURCES:
   Lightbox:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
-  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
-  Lightbox: e4523e8cf3261cbc833d0e76ae4dae774731d115
-  Sugar: 079e1375b76c8f0693474417836ef098f507ac50
+  Lightbox: 534c217c1bdc9933540b97191251d09a8a779878
 
 PODFILE CHECKSUM: cd88b68c201e5c39cef62070056649eaee91c71b
 

--- a/Lightbox.podspec
+++ b/Lightbox.podspec
@@ -13,6 +13,4 @@ Pod::Spec.new do |s|
   s.ios.resource = 'Resources/Lightbox.bundle'
 
   s.frameworks = 'UIKit', 'AVFoundation', 'AVKit'
-  s.dependency 'Sugar'
-  s.dependency 'Hue'
 end

--- a/Lightbox.xcodeproj/project.pbxproj
+++ b/Lightbox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		39AB92901E0A94030010D74C /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AB928F1E0A94030010D74C /* UIColor+Hex.swift */; };
 		D22006741DFB4D9700E92898 /* Lightbox.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D22006731DFB4D9700E92898 /* Lightbox.bundle */; };
 		D2D71BBC1D54DA77006AB907 /* AssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D71BBB1D54DA77006AB907 /* AssetManager.swift */; };
 		D5026B3C1C5BF3FD003BC1A3 /* LightboxImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5026B3B1C5BF3FD003BC1A3 /* LightboxImage.swift */; };
@@ -14,7 +15,6 @@
 		D523B0BE1C43AA8B001AD1EC /* LightboxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D523B0B71C43AA8A001AD1EC /* LightboxController.swift */; };
 		D54DFCBE1C5AAAD600ADEA0E /* InfoLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54DFCBC1C5AAAD600ADEA0E /* InfoLabel.swift */; };
 		D54DFCBF1C5AAAD600ADEA0E /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54DFCBD1C5AAAD600ADEA0E /* PageView.swift */; };
-		D54DFCC21C5AAAF100ADEA0E /* Hue.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D54DFCC01C5AAAF100ADEA0E /* Hue.framework */; };
 		D573A2F01C5B5605006053DD /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D573A2EF1C5B5605006053DD /* HeaderView.swift */; };
 		D573A2F31C5B5C7B006053DD /* LayoutConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D573A2F21C5B5C7B006053DD /* LayoutConfigurable.swift */; };
 		D573A2F51C5B5CA4006053DD /* LightboxTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D573A2F41C5B5CA4006053DD /* LightboxTransition.swift */; };
@@ -23,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		39AB928F1E0A94030010D74C /* UIColor+Hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
 		D22006731DFB4D9700E92898 /* Lightbox.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Lightbox.bundle; sourceTree = "<group>"; };
 		D2D71BBB1D54DA77006AB907 /* AssetManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetManager.swift; sourceTree = "<group>"; };
 		D5026B3B1C5BF3FD003BC1A3 /* LightboxImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LightboxImage.swift; sourceTree = "<group>"; };
@@ -32,7 +33,6 @@
 		D523B0B71C43AA8A001AD1EC /* LightboxController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LightboxController.swift; sourceTree = "<group>"; };
 		D54DFCBC1C5AAAD600ADEA0E /* InfoLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoLabel.swift; sourceTree = "<group>"; };
 		D54DFCBD1C5AAAD600ADEA0E /* PageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageView.swift; sourceTree = "<group>"; };
-		D54DFCC01C5AAAF100ADEA0E /* Hue.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Hue.framework; path = Carthage/Build/iOS/Hue.framework; sourceTree = "<group>"; };
 		D573A2EF1C5B5605006053DD /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		D573A2F21C5B5C7B006053DD /* LayoutConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutConfigurable.swift; sourceTree = "<group>"; };
 		D573A2F41C5B5CA4006053DD /* LightboxTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LightboxTransition.swift; sourceTree = "<group>"; };
@@ -45,7 +45,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D54DFCC21C5AAAF100ADEA0E /* Hue.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,7 +63,6 @@
 			isa = PBXGroup;
 			children = (
 				D22006721DFB4D9700E92898 /* Resources */,
-				D54DFCC01C5AAAF100ADEA0E /* Hue.framework */,
 				D523B0B41C43AA8A001AD1EC /* Source */,
 				D523B0AB1C43AA2A001AD1EC /* Lightbox */,
 				D523B0AA1C43AA2A001AD1EC /* Products */,
@@ -117,6 +115,7 @@
 				D573A2F41C5B5CA4006053DD /* LightboxTransition.swift */,
 				D573A2F21C5B5C7B006053DD /* LayoutConfigurable.swift */,
 				D573A2F61C5B5E55006053DD /* UIView+Gradient.swift */,
+				39AB928F1E0A94030010D74C /* UIColor+Hex.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -203,7 +202,6 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Hue.framework",
 			);
 			name = "Copy frameworks with Carthage";
 			outputPaths = (
@@ -228,6 +226,7 @@
 				D54DFCBE1C5AAAD600ADEA0E /* InfoLabel.swift in Sources */,
 				D58A18CB1C5ABF8F000024BB /* FooterView.swift in Sources */,
 				D573A2F01C5B5605006053DD /* HeaderView.swift in Sources */,
+				39AB92901E0A94030010D74C /* UIColor+Hex.swift in Sources */,
 				D573A2F51C5B5CA4006053DD /* LightboxTransition.swift in Sources */,
 				D2D71BBC1D54DA77006AB907 /* AssetManager.swift in Sources */,
 			);

--- a/Source/Library/UIColor+Hex.swift
+++ b/Source/Library/UIColor+Hex.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+public extension UIColor {
+    
+    convenience init(hex string: String) {
+        var hex = string.hasPrefix("#")
+            ? String(string.characters.dropFirst())
+            : string
+        guard hex.characters.count == 3 || hex.characters.count == 6
+            else {
+                self.init(white: 1.0, alpha: 0.0)
+                return
+        }
+        if hex.characters.count == 3 {
+            for (index, char) in hex.characters.enumerated() {
+                hex.insert(char, at: hex.index(hex.startIndex, offsetBy: index * 2))
+            }
+        }
+        
+        self.init(
+            red:   CGFloat((Int(hex, radix: 16)! >> 16) & 0xFF) / 255.0,
+            green: CGFloat((Int(hex, radix: 16)! >> 8) & 0xFF) / 255.0,
+            blue:  CGFloat((Int(hex, radix: 16)!) & 0xFF) / 255.0, alpha: 1.0)
+    }
+    
+    public func alpha(_ value: CGFloat) -> UIColor {
+        return withAlphaComponent(value)
+    }
+}

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Hue
 import AVKit
 import AVFoundation
 

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Hue
 
 public protocol LightboxControllerPageDelegate: class {
 


### PR DESCRIPTION
Removing dependency on Hue. 

I was playing with `ImagePicker` demo which required `LightBox` which in turn installed `Sugar` and `Hue` as dependencies.  I think we need to keep our libraries as independent as possible. 

In this case, it appears `Sugar` was removed by @onmyway133 in this [commit](https://github.com/hyperoslo/Lightbox/commit/98e3f62ebe14e187cef505b8fc7aa860363ca45b).

Now since `LightBox` is still dependent on `Hue` only for one function `UIColor(hex: String)`; i think we can remove dependency on `Hue` and implement this `UIColor+Hex` extension in `LightBox`itself.  Makes `LightBox` as standalone library with having redundant dependencies. 

What do you think?

