### PR TITLE
Auto-size Close and Delete buttons

### DIFF
--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -50,7 +50,7 @@ open class LightboxConfig {
 
   public struct CloseButton {
     public static var enabled = true
-    public static var size = CGSize(width: 60, height: 25)
+    public static var size: CGSize?
     public static var text = NSLocalizedString("Close", comment: "")
     public static var image: UIImage?
 
@@ -67,7 +67,7 @@ open class LightboxConfig {
 
   public struct DeleteButton {
     public static var enabled = false
-    public static var size = CGSize(width: 70, height: 25)
+    public static var size: CGSize?
     public static var text = NSLocalizedString("Delete", comment: "")
     public static var image: UIImage?
 

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -23,9 +23,9 @@ open class HeaderView: UIView {
     button.setAttributedTitle(title, for: UIControlState())
 
     if let size = LightboxConfig.CloseButton.size {
-        button.frame.size = size
+      button.frame.size = size
     } else {
-        button.sizeToFit()
+      button.sizeToFit()
     }
 
     button.addTarget(self, action: #selector(closeButtonDidPress(_:)),
@@ -50,9 +50,9 @@ open class HeaderView: UIView {
     button.setAttributedTitle(title, for: .normal)
 
     if let size = LightboxConfig.DeleteButton.size {
-        button.frame.size = size
+      button.frame.size = size
     } else {
-        button.sizeToFit()
+      button.sizeToFit()
     }
     
     button.addTarget(self, action: #selector(deleteButtonDidPress(_:)),

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -20,8 +20,14 @@ open class HeaderView: UIView {
 
     let button = UIButton(type: .system)
 
-    button.frame.size = LightboxConfig.CloseButton.size
     button.setAttributedTitle(title, for: UIControlState())
+
+    if let size = LightboxConfig.CloseButton.size {
+        button.frame.size = size
+    } else {
+        button.sizeToFit()
+    }
+
     button.addTarget(self, action: #selector(closeButtonDidPress(_:)),
       for: .touchUpInside)
 
@@ -41,8 +47,14 @@ open class HeaderView: UIView {
 
     let button = UIButton(type: .system)
 
-    button.frame.size = LightboxConfig.DeleteButton.size
     button.setAttributedTitle(title, for: .normal)
+
+    if let size = LightboxConfig.DeleteButton.size {
+        button.frame.size = size
+    } else {
+        button.sizeToFit()
+    }
+    
     button.addTarget(self, action: #selector(deleteButtonDidPress(_:)),
       for: .touchUpInside)
 


### PR DESCRIPTION
Hey Hyper Team 👋 

I had to translate the close button to German and this happened:

![img_1247](https://cloud.githubusercontent.com/assets/5942764/23891865/9554d52a-0898-11e7-9f5f-1e60351fd547.PNG)

With this PR, the size is based on the text with the help of `sizeToFit()`.
To not break the API for others, a size can still be set and will be used if it's not `nil`.

![img_1250](https://cloud.githubusercontent.com/assets/5942764/23891947/e6924f44-0898-11e7-9110-19863bed0695.PNG)

Have a sunny day 🌞 

Roman