### PR TITLE
Fix animation's completion not called on fast swipe on iOS9.0

### DIFF
--- a/Source/Library/LightboxTransition.swift
+++ b/Source/Library/LightboxTransition.swift
@@ -127,13 +127,13 @@ extension LightboxTransition: UIViewControllerAnimatedTransitioning {
 
     let duration = transitionDuration(using: transitionContext)
 
-    DispatchQueue.main.async { [unowned self] in
+    DispatchQueue.main.async {
         UIView.animate(withDuration: duration, animations: {
             self.transition(!self.dismissing)
         }, completion: { _ in
           transitionContext.transitionWasCancelled
-          ? transitionContext.completeTransition(false)
-          : transitionContext.completeTransition(true)
+            ? transitionContext.completeTransition(false)
+            : transitionContext.completeTransition(true)
         })
     }
   }

--- a/Source/Library/LightboxTransition.swift
+++ b/Source/Library/LightboxTransition.swift
@@ -128,13 +128,13 @@ extension LightboxTransition: UIViewControllerAnimatedTransitioning {
     let duration = transitionDuration(using: transitionContext)
 
     DispatchQueue.main.async {
-        UIView.animate(withDuration: duration, animations: {
-            self.transition(!self.dismissing)
+      UIView.animate(withDuration: duration, animations: {
+        self.transition(!self.dismissing)
         }, completion: { _ in
-          transitionContext.transitionWasCancelled
-            ? transitionContext.completeTransition(false)
-            : transitionContext.completeTransition(true)
-        })
+        transitionContext.transitionWasCancelled
+          ? transitionContext.completeTransition(false)
+          : transitionContext.completeTransition(true)
+      })
     }
   }
 }

--- a/Source/Library/LightboxTransition.swift
+++ b/Source/Library/LightboxTransition.swift
@@ -127,13 +127,15 @@ extension LightboxTransition: UIViewControllerAnimatedTransitioning {
 
     let duration = transitionDuration(using: transitionContext)
 
-    UIView.animate(withDuration: duration, animations: {
-      self.transition(!self.dismissing)
-      }, completion: { _ in
-        transitionContext.transitionWasCancelled
+    DispatchQueue.main.async { [unowned self] in
+        UIView.animate(withDuration: duration, animations: {
+            self.transition(!self.dismissing)
+        }, completion: { _ in
+          transitionContext.transitionWasCancelled
           ? transitionContext.completeTransition(false)
           : transitionContext.completeTransition(true)
-    })
+        })
+    }
   }
 }
 


### PR DESCRIPTION
Fix animation's completion not called on fast swipe on iOS9.0