### PR TITLE
Use key window bounds instead of screen bounds

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -82,7 +82,7 @@ open class LightboxController: UIViewController {
     }()
 
   var screenBounds: CGRect {
-    return UIScreen.main.bounds
+    return UIApplication.shared.delegate?.window??.bounds ?? .zero
   }
 
   // MARK: - Properties
@@ -267,7 +267,7 @@ open class LightboxController: UIViewController {
 
   // MARK: - Layout
 
-  open func configureLayout(_ size: CGSize = UIScreen.main.bounds.size) {
+  open func configureLayout(_ size: CGSize = UIApplication.shared.delegate?.window??.bounds.size ?? .zero) {
     scrollView.frame.size = size
     scrollView.contentSize = CGSize(
       width: size.width * CGFloat(numberOfPages) + spacing * CGFloat(numberOfPages - 1),


### PR DESCRIPTION
Thanks for the awesome library! I've noticed that the layout breaks on iPad in split screen mode because it relies on a call to `UIScreen.main.bounds` to perform layout calculations. I've switched to using the key window's bounds instead which fixes this problem.