### PR TITLE
Preserve correct Navigation Bar after dismissal when opened from a controller with a Nav Bar

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -199,8 +199,8 @@ open class LightboxController: UIViewController {
     }
   }
 
-  open override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
+  open override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
 
     if LightboxConfig.hideStatusBar {
       UIApplication.shared.setStatusBarHidden(statusBarHidden, with: .fade)


### PR DESCRIPTION
This PR fixes https://github.com/hyperoslo/Lightbox/issues/93
When the Lightbox was dismissed, the Navigation Bar (if any) was appearing at (0,0) not respecting the presence of Status Bar. It was happening because the Status Bar was turned back on too late. Making the statusBar update earlier - in viewWillDisappear - fixes this issue.