### PR TITLE
Cutting long texts quicker

### DIFF
--- a/Source/Views/InfoLabel.swift
+++ b/Source/Views/InfoLabel.swift
@@ -47,6 +47,10 @@ open class InfoLabel: UILabel {
     guard numberOfLines(fullText) > numberOfVisibleLines else {
       return truncatedText
     }
+    
+    while numberOfLines(truncatedText) > numberOfVisibleLines * 2 {
+        truncatedText = String(truncatedText.characters.prefix(truncatedText.characters.count / 2))
+    }
 
     truncatedText += ellipsis
 


### PR DESCRIPTION
This PR fixes issue https://github.com/hyperoslo/Lightbox/issues/117
A long text will be truncated quickly until it remains twice longer than numberOfVisibleLines. So that the existing character-by-character algorithm always starts with a short text.