### PR TITLE
Updating the image frames while images are still being loaded

### DIFF
--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -132,7 +132,10 @@ class PageView: UIScrollView {
   }
 
   func configureImageView() {
-    guard let image = imageView.image else { return }
+    guard let image = imageView.image else {
+        centerImageView()
+        return
+    }
 
     let imageViewSize = imageView.frame.size
     let imageSize = image.size


### PR DESCRIPTION
This PR fixes issue https://github.com/hyperoslo/Lightbox/issues/108 and (duplicate?) issue https://github.com/hyperoslo/Lightbox/issues/116
Lightbox behaves much better on low latency network in terms of UI now - it will correctly show progress indicator while an image is being loaded (an empty slot was appearing before, and it looked as if nothing was going to happen).