### PR TITLE
Updating the .image property of a LightboxImage instance after Lightbox has downloaded an image via URL

### DIFF
--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -26,7 +26,8 @@ open class LightboxImage {
       imageView.image = image
       completion?(image)
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView, imageURL) { error, image in
+      LightboxConfig.loadImage(imageView, imageURL) { [weak self] error, image in
+        self?.image = image
         completion?(image)
       }
     }


### PR DESCRIPTION
...continuing from PR https://github.com/hyperoslo/Lightbox/pull/115 (which was created from master by mistake).

> This change allows apps to access the images inside LightboxImage even if those images were downloaded from an external URL provided by the app.
> Can be useful, for example, when an app needs to provide sharing functionality.
> See example of such a usage in #98 