### PR TITLE
Fixed two bugs.

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -188,23 +188,14 @@ open class LightboxController: UIViewController {
 
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-
-    if LightboxConfig.hideStatusBar {
-      UIApplication.shared.setStatusBarHidden(true, with: .fade)
-    }
-
     if !presented {
       presented = true
       configureLayout()
     }
   }
 
-  open override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-
-    if LightboxConfig.hideStatusBar {
-      UIApplication.shared.setStatusBarHidden(statusBarHidden, with: .fade)
-    }
+  open override var prefersStatusBarHidden: Bool {
+    return LightboxConfig.hideStatusBar
   }
 
   // MARK: - Rotation

--- a/Source/Views/FooterView.swift
+++ b/Source/Views/FooterView.swift
@@ -108,7 +108,7 @@ extension FooterView: InfoLabelDelegate {
 
   public func infoLabel(_ infoLabel: InfoLabel, didExpand expanded: Bool) {
     resetFrames()
-    _ = expanded ? removeGradientLayer() : addGradientLayer(gradientColors)
+    _ = (expanded || infoLabel.fullText.isEmpty) ? removeGradientLayer() : addGradientLayer(gradientColors)
     delegate?.footerView(self, didExpand: expanded)
   }
 }


### PR DESCRIPTION
#### Bug 1

`setStatusBarHidden(_:with:)` was deprecated, causing `LightboxConfig.hideStatusBar = true` not work.

**Fix:** switched to `prefersStatusBarHidden` property to implement it.

#### Bug 2

When infoLabel's `fullText` is empty, the footer doesn't remove gradient layer properly.  
Gradient layer should be removed from footer view if infoLabel's fullText is empty, regardless of expanded state.

**Fix:** added `infoLabel.fullText.isEmpty` check in FooterView InfoLabelDelegate extension. 