### PR TITLE
project: update continuous integration setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-osx_image: xcode8
-language: objective-c
+osx_image: xcode8.3
+language: swift
 
 before_install:
 - brew update


### PR DESCRIPTION
Hello!

This commit updates the continuous integration setup by selecting the
Xcode 8.3 osx_image and by indicating that the project is written in
swift.

Indeed, the continuous integration was broken, as the Carthage update
(0.24) needs this version of Xcode [1]

Thank you.

[1] https://travis-ci.org/hyperoslo/Lightbox/builds/268485681

