### PR TITLE
Specified Hue dependency version in podspec - Issue 137

### DIFF
--- a/Lightbox.podspec
+++ b/Lightbox.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.ios.resource = 'Resources/Lightbox.bundle'
 
   s.frameworks = 'UIKit', 'AVFoundation', 'AVKit'
-  s.dependency 'Hue'
+  s.dependency 'Hue', '2.0.1'
 
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0' }
 end


### PR DESCRIPTION
Hi,
I specified version of Hue dependency in podspec to make this library compatible with Swift 3.2 projects opened in Xcode 9. See [issue 137](https://github.com/hyperoslo/Lightbox/issues/137).

Tomas