### PR TITLE
Use String directly instead of String.characters

### DIFF
--- a/Source/Views/InfoLabel.swift
+++ b/Source/Views/InfoLabel.swift
@@ -50,7 +50,7 @@ open class InfoLabel: UILabel {
 
     // Perform quick "rough cut"
     while numberOfLines(truncatedText) > numberOfVisibleLines * 2 {
-        truncatedText = String(truncatedText.characters.prefix(truncatedText.characters.count / 2))
+        truncatedText = String(truncatedText.prefix(truncatedText.count / 2))
     }
 
     // Capture the endIndex of truncatedText before appending ellipsis


### PR DESCRIPTION
String has changed in Swift 4: https://github.com/apple/swift/blob/master/docs/StringManifesto.md

Using `String.characters` is now deprecated and shows a warning when building. `String` itself is now a Collection of Characters, and can be accessed directly where we previously had to use `String.characters`. :)