### PR TITLE
Fix footer counter

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -335,7 +335,7 @@ extension LightboxController: UIScrollViewDelegate {
     }
 
     targetContentOffset.pointee.x = x
-    currentPage = Int(x / view.bounds.width)
+    currentPage = Int(x / pageWidth)
   }
 }
 


### PR DESCRIPTION
Bug: 
Page counter displays incorrect value for 41 images. E.g. counter is jumping from 19 to 21 on iPhone 8. 

Steps to reproduce: 
1. Open Lightbox with 41 images. 
2. Scroll back and forward. 
Expected: 
Page counter is displaying correct values. 
Actual: 
Page counter jumps from n to n+2. Last pictures are showing the same 41 counter value.  

Bug reason: you should take into account spacing while calculating current page. 