### PR TITLE
Added possibility to set image preload value

### DIFF
--- a/Lightbox.xcodeproj/project.pbxproj
+++ b/Lightbox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		166E3BA920333E04006799C1 /* LightboxImageStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166E3BA820333E04006799C1 /* LightboxImageStub.swift */; };
 		D22006741DFB4D9700E92898 /* Lightbox.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D22006731DFB4D9700E92898 /* Lightbox.bundle */; };
 		D229B5E61FC3123F00F04123 /* Lightbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D523B0A91C43AA2A001AD1EC /* Lightbox.framework */; };
 		D229B5ED1FC3125D00F04123 /* InfoLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D229B5EC1FC3125D00F04123 /* InfoLabelTests.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		166E3BA820333E04006799C1 /* LightboxImageStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightboxImageStub.swift; sourceTree = "<group>"; };
 		D22006731DFB4D9700E92898 /* Lightbox.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Lightbox.bundle; sourceTree = "<group>"; };
 		D229B5E11FC3123F00F04123 /* Lightbox-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Lightbox-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D229B5E51FC3123F00F04123 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				D523B0B61C43AA8A001AD1EC /* LightboxConfig.swift */,
 				D523B0B71C43AA8A001AD1EC /* LightboxController.swift */,
 				D5026B3B1C5BF3FD003BC1A3 /* LightboxImage.swift */,
+				166E3BA820333E04006799C1 /* LightboxImageStub.swift */,
 				D2D71BBB1D54DA77006AB907 /* AssetManager.swift */,
 			);
 			path = Source;
@@ -316,6 +319,7 @@
 				D58A18CB1C5ABF8F000024BB /* FooterView.swift in Sources */,
 				D573A2F01C5B5605006053DD /* HeaderView.swift in Sources */,
 				D573A2F51C5B5CA4006053DD /* LightboxTransition.swift in Sources */,
+				166E3BA920333E04006799C1 /* LightboxImageStub.swift in Sources */,
 				D2D71BBC1D54DA77006AB907 /* AssetManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -36,6 +36,11 @@ public class LightboxConfig {
   public static var makeLoadingIndicator: () -> UIView = {
     return LoadingIndicator()
   }
+  
+  /// Number of images to preload.
+  ///
+  /// 0 - Preload all images (default).
+  public static var preload = 0
 
   public struct PageIndicator {
     public static var enabled = true

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -91,7 +91,7 @@ open class LightboxController: UIViewController {
         seen = true
       }
 
-      reconfigurePreloadedPages()
+      reconfigurePagesForPreload()
       
       pageDelegate?.lightboxController(self, didMoveToPage: currentPage)
       

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -175,9 +175,8 @@ open class LightboxController: UIViewController {
     overlayView.addGestureRecognizer(overlayTapGestureRecognizer)
 
     configurePages(initialImages)
-    currentPage = initialPage
 
-    goTo(currentPage, animated: false)
+    goTo(initialPage, animated: false)
   }
 
   open override func viewDidAppear(_ animated: Bool) {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -342,8 +342,8 @@ open class LightboxController: UIViewController {
     let preload = LightboxConfig.preload
     if preload > 0 {
       let lb = max(0, currentPage - preload)
-      let rb = min(initialImages.count - 1, currentPage + preload)
-      for i in lb...rb {
+      let rb = min(initialImages.count, currentPage + preload)
+      for i in lb..<rb {
         preloadIndicies.append(i)
       }
     } else {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -91,8 +91,10 @@ open class LightboxController: UIViewController {
         seen = true
       }
 
+      reconfigurePreloadedPages()
+      
       pageDelegate?.lightboxController(self, didMoveToPage: currentPage)
-
+      
       if let image = pageViews[currentPage].imageView.image, dynamicBackground {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.125) {
           self.loadDynamicBackground(image)
@@ -130,6 +132,7 @@ open class LightboxController: UIViewController {
       return pageViews.map { $0.image }
     }
     set(value) {
+      initialImages = value
       configurePages(value)
     }
   }
@@ -144,7 +147,7 @@ open class LightboxController: UIViewController {
   var pageViews = [PageView]()
   var statusBarHidden = false
 
-  fileprivate let initialImages: [LightboxImage]
+  fileprivate var initialImages: [LightboxImage]
   fileprivate let initialPage: Int
 
   // MARK: - Initializers
@@ -228,16 +231,35 @@ open class LightboxController: UIViewController {
   func configurePages(_ images: [LightboxImage]) {
     pageViews.forEach { $0.removeFromSuperview() }
     pageViews = []
-
-    for image in images {
-      let pageView = PageView(image: image)
+    
+    let preloadIndicies = calculatePreloadIndicies()
+    
+    for i in 0..<images.count {
+      let pageView = PageView(image: preloadIndicies.contains(i) ? images[i] : LightboxImageStub())
       pageView.pageViewDelegate = self
-
+      
       scrollView.addSubview(pageView)
       pageViews.append(pageView)
     }
-
+    
     configureLayout(view.bounds.size)
+  }
+  
+  func reconfigurePagesForPreload() {
+    let preloadIndicies = calculatePreloadIndicies()
+    
+    for i in 0..<initialImages.count {
+      let pageView = pageViews[i]
+      if preloadIndicies.contains(i) {
+        if type(of: pageView.image) == LightboxImageStub.self {
+          pageView.update(with: initialImages[i])
+        }
+      } else {
+        if type(of: pageView.image) != LightboxImageStub.self {
+          pageView.update(with: LightboxImageStub())
+        }
+      }
+    }
   }
 
   // MARK: - Pagination
@@ -311,6 +333,23 @@ open class LightboxController: UIViewController {
       self.footerView.alpha = alpha
       pageView?.playButton.alpha = alpha
     }, completion: nil)
+  }
+  
+  // MARK: - Helper functions
+  
+  func calculatePreloadIndicies () -> [Int] {
+    var preloadIndicies: [Int] = []
+    let preload = LightboxConfig.preload
+    if preload > 0 {
+      let lb = max(0, currentPage - preload)
+      let rb = min(initialImages.count - 1, currentPage + preload)
+      for i in lb...rb {
+        preloadIndicies.append(i)
+      }
+    } else {
+      preloadIndicies = [Int](0..<initialImages.count)
+    }
+    return preloadIndicies
   }
 }
 

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -43,6 +43,9 @@ open class LightboxImage {
       let img = imageClosure()
       imageView.image = img
       completion?(img)
+    } else {
+      imageView.image = nil
+      completion?(nil)
     }
   }
 }

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -10,6 +10,10 @@ open class LightboxImage {
   open var text: String
 
   // MARK: - Initialization
+  
+  internal init(text: String = "") {
+    self.text = text
+  }
 
   public init(image: UIImage, text: String = "", videoURL: URL? = nil) {
     self.image = image

--- a/Source/LightboxImageStub.swift
+++ b/Source/LightboxImageStub.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+internal class LightboxImageStub: LightboxImage {
+  
+  // MARK: - Initialization
+  
+  init () {
+    super.init()
+  }
+  
+}
+
+

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -51,20 +51,7 @@ class PageView: UIScrollView {
 
     configure()
 
-    loadingIndicator.alpha = 1
-    self.image.addImageTo(imageView) { [weak self] image in
-      guard let strongSelf = self else {
-        return
-      }
-
-      strongSelf.isUserInteractionEnabled = true
-      strongSelf.configureImageView()
-      strongSelf.pageViewDelegate?.remoteImageDidLoad(image, imageView: strongSelf.imageView)
-
-      UIView.animate(withDuration: 0.4) {
-        strongSelf.loadingIndicator.alpha = 0
-      }
-    }
+    fetchImage()
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -76,9 +63,7 @@ class PageView: UIScrollView {
   func configure() {
     addSubview(imageView)
 
-    if image.videoURL != nil {
-      addSubview(playButton)
-    }
+    updatePlayButton()
 
     addSubview(loadingIndicator)
 
@@ -98,6 +83,41 @@ class PageView: UIScrollView {
     addGestureRecognizer(tapRecognizer)
 
     tapRecognizer.require(toFail: doubleTapRecognizer)
+  }
+  
+  // MARK: - Update
+  
+  func update(with image: LightboxImage) {
+    self.image = image
+    updatePlayButton()
+    fetchImage()
+  }
+  
+  func updatePlayButton () {
+    if self.image.videoURL != nil && !subviews.contains(playButton) {
+      addSubview(playButton)
+    } else if self.image.videoURL == nil && subviews.contains(playButton) {
+      playButton.removeFromSuperview()
+    }
+  }
+  
+  //MARK: - Fetch
+  
+  private func fetchImage () {
+    loadingIndicator.alpha = 1
+    self.image.addImageTo(imageView) { [weak self] image in
+      guard let strongSelf = self else {
+        return
+      }
+      
+      strongSelf.isUserInteractionEnabled = true
+      strongSelf.configureImageView()
+      strongSelf.pageViewDelegate?.remoteImageDidLoad(image, imageView: strongSelf.imageView)
+      
+      UIView.animate(withDuration: 0.4) {
+        strongSelf.loadingIndicator.alpha = 0
+      }
+    }
   }
 
   // MARK: - Recognizers


### PR DESCRIPTION
I tried to load the LightboxController with hundreds of images, and ran into memory issues.

As of now, Lightbox loads all the passed images at once, creating a memory usage spike for a high amount of images. Also it keeps all of them in memory, which is not optimal for large numbers of images. 

Therefore, it might be useful to have a possibility to set a number of images, which the user will have loaded at a time.
I implemented it in this PR. 

So if preload = 0, we load all the images (default behavior), if it equals to 2, we load:
-**2**, -**1**, **0**(current image), **1**, **2**.
