### PR TITLE
Remove references to Hue, which is no longer used.

### DIFF
--- a/Lightbox.xcodeproj/project.pbxproj
+++ b/Lightbox.xcodeproj/project.pbxproj
@@ -53,7 +53,6 @@
 		D523B0B71C43AA8A001AD1EC /* LightboxController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LightboxController.swift; sourceTree = "<group>"; };
 		D54DFCBC1C5AAAD600ADEA0E /* InfoLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoLabel.swift; sourceTree = "<group>"; };
 		D54DFCBD1C5AAAD600ADEA0E /* PageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageView.swift; sourceTree = "<group>"; };
-		D54DFCC01C5AAAF100ADEA0E /* Hue.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Hue.framework; path = Carthage/Build/iOS/Hue.framework; sourceTree = "<group>"; };
 		D56F15C71E0AB79800F128AF /* LoadingIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
 		D573A2EF1C5B5605006053DD /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		D573A2F21C5B5C7B006053DD /* LayoutConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutConfigurable.swift; sourceTree = "<group>"; };
@@ -111,7 +110,6 @@
 			isa = PBXGroup;
 			children = (
 				D22006721DFB4D9700E92898 /* Resources */,
-				D54DFCC01C5AAAF100ADEA0E /* Hue.framework */,
 				D523B0B41C43AA8A001AD1EC /* Source */,
 				D523B0AB1C43AA2A001AD1EC /* Lightbox */,
 				D229B5E21FC3123F00F04123 /* Lightbox-iOS-Tests */,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ packed with all the features you expect:
 - [x] Video support.
 - [x] Double-tap to zoom.
 - [x] Image caption.
-- [x] Dynamic background based on [Hue](https://github.com/hyperoslo/Hue)
+- [x] Dynamic background.
 - [x] Remote image loading and caching based on [Imaginary](https://github.com/hyperoslo/Imaginary)
 - [x] Interactive transition animations.
 - [x] Powerful configuration.


### PR DESCRIPTION
The README and project file still reference [Hue](https://github.com/hyperoslo/Hue), even though the dynamic background is now implemented based on `UIBlurEffect`.