### PR TITLE
Add ability to cancel image preloading

### DIFF
--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -18,7 +18,7 @@ public class LightboxConfig {
   }
 
   /// How to load image onto UIImageView
-  public static var loadImage: (UIImageView, URL, ((UIImage?) -> Void)?) -> Void = { (imageView, imageURL, completion) in
+  public static var loadImage: (UIImageView, URL, inout (() -> Void)?, ((UIImage?) -> Void)?) -> Void = { (imageView, imageURL, cancelOperation, completion) in
 
     // Use Imaginary by default
     imageView.setImage(url: imageURL, placeholder: nil, completion: { result in

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -33,12 +33,14 @@ open class LightboxImage {
     self.videoURL = videoURL
   }
 
-  open func addImageTo(_ imageView: UIImageView, completion: ((UIImage?) -> Void)? = nil) {
+  open func addImageTo(_ imageView: UIImageView, completion: ((UIImage?) -> Void)? = nil) -> (() -> Void)? {
     if let image = image {
       imageView.image = image
       completion?(image)
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView, imageURL, completion)
+      var cancelOperation: (() -> Void)? = nil
+      LightboxConfig.loadImage(imageView, imageURL, &cancelOperation, completion)
+      return cancelOperation
     } else if let imageClosure = imageClosure {
       let img = imageClosure()
       imageView.image = img
@@ -47,5 +49,6 @@ open class LightboxImage {
       imageView.image = nil
       completion?(nil)
     }
+    return nil
   }
 }

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -39,6 +39,8 @@ class PageView: UIScrollView {
   var contentFrame = CGRect.zero
   weak var pageViewDelegate: PageViewDelegate?
 
+  private var cancelCurrentImageLoading: (() -> Void)?
+
   var hasZoomed: Bool {
     return zoomScale != 1.0
   }
@@ -102,11 +104,15 @@ class PageView: UIScrollView {
 
   // MARK: - Fetch
   private func fetchImage () {
+    cancelCurrentImageLoading?()
+
     loadingIndicator.alpha = 1
-    self.image.addImageTo(imageView) { [weak self] image in
+    cancelCurrentImageLoading = self.image.addImageTo(imageView) { [weak self] image in
       guard let self = self else {
         return
       }
+
+      self.cancelCurrentImageLoading = nil
 
       self.isUserInteractionEnabled = true
       self.configureImageView()


### PR DESCRIPTION
Preloading operations currently cannot be cancelled, which may result in a number of redundant background operations fetching images that are no longer needed. The default implementation uses a complicated workaround using associated objects to be able to cancel previous fetch operations (I believe this specific code is part of Imaginary). To allow custom image providers (via `LightboxConfig.loadImage`) to be able to cancel operations when the preloading operation is no longer needed, I added a cancel operation to `LightboxConfig.loadImage`. This closure may be provided by the implementation of `LightboxConfig.loadImage` and will be called when the specific requested image no longer needs to be prefetched (i.e. the associated image view receives a new image to fetch).

Moreover, a non-cancelled image prefetch operation will end up setting the image of an image view that no longer requested that image, which results in displaying incorrect images.