### PR TITLE
Change UIColor hex extension to internal visibility

### DIFF
--- a/Source/Library/Color+Extensions.swift
+++ b/Source/Library/Color+Extensions.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public extension UIColor {
+internal extension UIColor {
     /// Constructing color from hex string
     ///
     /// - Parameter hex: A hex string, can either contain # or not


### PR DESCRIPTION
Using public visibility means that developers are unable to simultaneously use `Hue` along with `Lightbox` since both modules contain a globally imported extension of the same format: `UIColor.init(hex: String)`. Any project using the latest versions of both libraries will fail to compile if the hex initializer is used anywhere due to ambiguity in resolving the method.

I definitely see the reasoning behind removing the dependency on `Hue`, but the hex color extension is really only used internally to `Lightbox` and doesn't need to be publicly accessible in the module since it is wholly unrelated to the core purpose of `Lightbox`.