### PR TITLE
Move configureLayout(_) in viewDidLayoutSubviews()

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -185,14 +185,6 @@ open class LightboxController: UIViewController {
     goTo(initialPage, animated: false)
   }
 
-  open override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    if !presented {
-      presented = true
-      configureLayout(view.bounds.size)
-    }
-  }
-
   open override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
@@ -213,6 +205,11 @@ open class LightboxController: UIViewController {
       width: view.bounds.width,
       height: 100
     )
+    
+    if !presented {
+      presented = true
+      configureLayout(view.bounds.size)
+    }
   }
 
   open override var prefersStatusBarHidden: Bool {


### PR DESCRIPTION
This PR fixes a little issue I got when using Lightbox with SwiftUI, when showed as a modal. What happened was that the layout is adjusted to make space for the text below the image only after the view appeared. Expected behavior since the `configureLayout(_)` was in `viewDidAppear`...
By configuring the layout inside `viewDidLayoutSubviews()`, when the view appears, it is configured with the final frame but before presentation, which makes the UI correct when it is presenting (before `viewDidAppear` is called).