### PR TITLE
Keeping an image, downloaded from Internet, for future use

### DIFF
--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -38,8 +38,8 @@ open class LightboxImage {
       imageView.image = image
       completion?(image)
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView, imageURL) { downloadedImage in
-        self.image = downloadedImage
+      LightboxConfig.loadImage(imageView, imageURL) { [weak self] downloadedImage in
+        self?.image = downloadedImage
         completion?(downloadedImage)
       }
     } else if let imageClosure = imageClosure {

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -38,7 +38,10 @@ open class LightboxImage {
       imageView.image = image
       completion?(image)
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView, imageURL, completion)
+      LightboxConfig.loadImage(imageView, imageURL) { downloadedImage in
+        self.image = downloadedImage
+        completion?(downloadedImage)
+      }
     } else if let imageClosure = imageClosure {
       let img = imageClosure()
       imageView.image = img


### PR DESCRIPTION
At the moment, if you add an image inited from an UIImage this way:
`LightboxImage(image: UIImage(named: "photo1")!, text: "This is an example of a remote image loaded from URL")`
it is going to be accessible via `lightbox.[pageNumber].image`.

However, this property is going to be nil if you init an image from a URL this way:
`LightboxImage(imageURL: URL(string: "https://cdn.arstechnica.net/2011/10/05/iphone4s_sample_apple-4e8c706-intro.jpg")!)`

This is a regression, because it has already been fixed long time ago in PR https://github.com/hyperoslo/Lightbox/pull/122

This PR fixes it and makes the image to be accessible again via `lightbox.[pageNumber].image` in case it is inited as URL, assuming user has opened it and it was loaded.