### PR TITLE
Using SDWedImage instead Imginery for caching

### DIFF
--- a/Lightbox.podspec
+++ b/Lightbox.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.ios.resource = 'Resources/Lightbox.bundle'
 
   s.frameworks = 'UIKit', 'AVFoundation', 'AVKit'
-  s.dependency 'Imaginary', '~> 5.0.0'
+  s.dependency 'SDWebImage'
   s.swift_version = '5.0'
 
 end

--- a/Lightbox.xcodeproj/project.pbxproj
+++ b/Lightbox.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,11 +14,9 @@
 		44E6A65C2495BFD400543CF0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E6A65B2495BFD400543CF0 /* ViewController.swift */; };
 		44E6A6652495C0EB00543CF0 /* Lightbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D523B0A91C43AA2A001AD1EC /* Lightbox.framework */; };
 		44E6A6662495C0EB00543CF0 /* Lightbox.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D523B0A91C43AA2A001AD1EC /* Lightbox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		44E6A66A2495C13F00543CF0 /* Imaginary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2A58F5D1F7943A30064F14E /* Imaginary.framework */; };
-		44E6A66B2495C13F00543CF0 /* Imaginary.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2A58F5D1F7943A30064F14E /* Imaginary.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		85CB007027B16C6900A47BB3 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = 85CB006F27B16C6900A47BB3 /* SDWebImage */; };
 		D22006741DFB4D9700E92898 /* Lightbox.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D22006731DFB4D9700E92898 /* Lightbox.bundle */; };
 		D2258CC4215CD035005A9A1C /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2258CC3215CD035005A9A1C /* Color+Extensions.swift */; };
-		D2A58F5E1F7943A30064F14E /* Imaginary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2A58F5D1F7943A30064F14E /* Imaginary.framework */; };
 		D2D71BBC1D54DA77006AB907 /* AssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D71BBB1D54DA77006AB907 /* AssetManager.swift */; };
 		D5026B3C1C5BF3FD003BC1A3 /* LightboxImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5026B3B1C5BF3FD003BC1A3 /* LightboxImage.swift */; };
 		D523B0BD1C43AA8B001AD1EC /* LightboxConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D523B0B61C43AA8A001AD1EC /* LightboxConfig.swift */; };
@@ -50,7 +48,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				44E6A66B2495C13F00543CF0 /* Imaginary.framework in Embed Frameworks */,
 				44E6A6662495C0EB00543CF0 /* Lightbox.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -90,7 +87,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44E6A66A2495C13F00543CF0 /* Imaginary.framework in Frameworks */,
 				44E6A6652495C0EB00543CF0 /* Lightbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -99,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D2A58F5E1F7943A30064F14E /* Imaginary.framework in Frameworks */,
+				85CB007027B16C6900A47BB3 /* SDWebImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -248,6 +244,9 @@
 			dependencies = (
 			);
 			name = "Lightbox-iOS";
+			packageProductDependencies = (
+				85CB006F27B16C6900A47BB3 /* SDWebImage */,
+			);
 			productName = Lightbox;
 			productReference = D523B0A91C43AA2A001AD1EC /* Lightbox.framework */;
 			productType = "com.apple.product-type.framework";
@@ -259,7 +258,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1150;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "Hyper Interaktiv AS";
 				TargetAttributes = {
 					44E6A6462495BFAB00543CF0 = {
@@ -281,6 +280,9 @@
 				Base,
 			);
 			mainGroup = D523B09F1C43AA2A001AD1EC;
+			packageReferences = (
+				85CB006E27B16C6900A47BB3 /* XCRemoteSwiftPackageReference "SDWebImage" */,
+			);
 			productRefGroup = D523B0AA1C43AA2A001AD1EC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -381,8 +383,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = iOSDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.elvisnunez.iOSDemo;
@@ -410,8 +415,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = iOSDemo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.elvisnunez.iOSDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -527,7 +535,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -550,8 +559,12 @@
 				);
 				INFOPLIST_FILE = Lightbox/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Lightbox;
 				PRODUCT_NAME = Lightbox;
 				SKIP_INSTALL = YES;
@@ -575,8 +588,12 @@
 				);
 				INFOPLIST_FILE = Lightbox/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.Lightbox;
 				PRODUCT_NAME = Lightbox;
 				SKIP_INSTALL = YES;
@@ -617,6 +634,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		85CB006E27B16C6900A47BB3 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		85CB006F27B16C6900A47BB3 /* SDWebImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 85CB006E27B16C6900A47BB3 /* XCRemoteSwiftPackageReference "SDWebImage" */;
+			productName = SDWebImage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D523B0A01C43AA2A001AD1EC /* Project object */;
 }

--- a/Lightbox.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Lightbox.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Lightbox.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Lightbox.xcodeproj/xcshareddata/xcschemes/Lightbox-iOS.xcscheme
+++ b/Lightbox.xcodeproj/xcshareddata/xcschemes/Lightbox-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,12 @@ let package = Package(
             targets: ["Lightbox"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/hyperoslo/Imaginary", .branch("master"))
+      .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.1.0")
     ],
     targets: [
         .target(
             name: "Lightbox",
-            dependencies: ["Imaginary"],
+            dependencies: ["SDWebImage"],
             path: "Source"
             )
     ],

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -1,7 +1,7 @@
 import UIKit
 import AVKit
 import AVFoundation
-import Imaginary
+import SDWebImage
 
 public class LightboxConfig {
   /// Whether to show status bar while Lightbox is presented
@@ -17,18 +17,13 @@ public class LightboxConfig {
     }
   }
 
-  /// How to load image onto UIImageView
-  public static var loadImage: (UIImageView, URL, ((UIImage?) -> Void)?) -> Void = { (imageView, imageURL, completion) in
+  /// How to load image onto SDAnimatedImageView
+  public static var loadImage: (SDAnimatedImageView, URL, ((UIImage?) -> Void)?) -> Void = { (imageView, imageURL, completion) in
 
-    // Use Imaginary by default
-    imageView.setImage(url: imageURL, placeholder: nil, completion: { result in
-      switch result {
-      case .value(let image):
-        completion?(image)
-      case .error:
-        completion?(nil)
-      }
-    })
+    // Use SDWebImage by default
+    imageView.sd_setImage(with: imageURL) { image, error, _ , _ in
+      completion?(image)
+    }
   }
 
   /// Indicator is used to show while image is being fetched

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -1,16 +1,17 @@
 import UIKit
+import SDWebImage
 
-public protocol LightboxControllerPageDelegate: class {
+public protocol LightboxControllerPageDelegate: AnyObject {
 
   func lightboxController(_ controller: LightboxController, didMoveToPage page: Int)
 }
 
-public protocol LightboxControllerDismissalDelegate: class {
+public protocol LightboxControllerDismissalDelegate: AnyObject {
 
   func lightboxControllerWillDismiss(_ controller: LightboxController)
 }
 
-public protocol LightboxControllerTouchDelegate: class {
+public protocol LightboxControllerTouchDelegate: AnyObject {
 
   func lightboxController(_ controller: LightboxController, didTouch image: LightboxImage, at index: Int)
 }
@@ -44,8 +45,8 @@ open class LightboxController: UIViewController {
     return view
   }()
 
-  lazy var backgroundView: UIImageView = {
-    let view = UIImageView()
+  lazy var backgroundView: SDAnimatedImageView = {
+    let view = SDAnimatedImageView()
     view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
     return view
@@ -383,7 +384,7 @@ extension LightboxController: UIScrollViewDelegate {
 
 extension LightboxController: PageViewDelegate {
 
-  func remoteImageDidLoad(_ image: UIImage?, imageView: UIImageView) {
+  func remoteImageDidLoad(_ image: UIImage?, imageView: SDAnimatedImageView) {
     guard let image = image, dynamicBackground else {
       return
     }

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -1,5 +1,5 @@
 import UIKit
-import Imaginary
+import SDWebImage
 
 open class LightboxImage {
 
@@ -33,7 +33,7 @@ open class LightboxImage {
     self.videoURL = videoURL
   }
 
-  open func addImageTo(_ imageView: UIImageView, completion: ((UIImage?) -> Void)? = nil) {
+  open func addImageTo(_ imageView: SDAnimatedImageView, completion: ((UIImage?) -> Void)? = nil) {
     if let image = image {
       imageView.image = image
       completion?(image)

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -1,17 +1,18 @@
 import UIKit
+import SDWebImage
 
-protocol PageViewDelegate: class {
+protocol PageViewDelegate: AnyObject {
 
   func pageViewDidZoom(_ pageView: PageView)
-  func remoteImageDidLoad(_ image: UIImage?, imageView: UIImageView)
+  func remoteImageDidLoad(_ image: UIImage?, imageView: SDAnimatedImageView)
   func pageView(_ pageView: PageView, didTouchPlayButton videoURL: URL)
   func pageViewDidTouch(_ pageView: PageView)
 }
 
 class PageView: UIScrollView {
 
-  lazy var imageView: UIImageView = {
-    let imageView = UIImageView()
+  lazy var imageView: SDAnimatedImageView = {
+    let imageView = SDAnimatedImageView()
     imageView.contentMode = .scaleAspectFit
     imageView.clipsToBounds = true
     imageView.isUserInteractionEnabled = true

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -22,12 +22,16 @@ class ViewController: UIViewController {
     view.backgroundColor = UIColor.white
     view.addSubview(showButton)
     title = "Lightbox"
+    LightboxConfig.preload = 2
   }
   
   // MARK: - Action methods
   
     @objc func showLightbox() {
         let images = [
+            LightboxImage(imageURL: URL(string: "https://media.giphy.com/media/Ku65904QQe4yez448B/giphy.gif")!),
+            LightboxImage(imageURL: URL(string: "https://media.giphy.com/media/lQDLwWUMPaAHvh8pAG/giphy.gif")!),
+            LightboxImage(imageURL: URL(string: "https://media.giphy.com/media/ontKwPWJxARsuKaKqJ/giphy.gif")!),
             LightboxImage(
                 image: UIImage(named: "photo1")!,
                 text: "Photography is the science, art, application and practice of creating durable images by recording light or other electromagnetic radiation, either electronically by means of an image sensor, or chemically by means of a light-sensitive material such as photographic film"
@@ -44,7 +48,8 @@ class ViewController: UIViewController {
             LightboxImage(
                 image: UIImage(named: "photo3")!,
                 text: "A lightbox is a translucent surface illuminated from behind, used for situations where a shape laid upon the surface needs to be seen with high contrast."
-            )
+            ),
+            LightboxImage(imageURL: URL(string: "https://c.tenor.com/kccsHXtdDn0AAAAC/alcohol-wine.gif")!)
         ]
         
         let controller = LightboxController(images: images)


### PR DESCRIPTION
This PR uses SDWebImage for image caching. The main reason is to support animated gif(not loading all frames into memory when playing)