### PR TITLE
Remove dependencies on specific image request library

### DIFF
--- a/Lightbox.podspec
+++ b/Lightbox.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.ios.resource = 'Resources/Lightbox.bundle'
 
   s.frameworks = 'UIKit', 'AVFoundation', 'AVKit'
-  s.dependency 'SDWebImage'
   s.swift_version = '5.0'
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,11 @@ let package = Package(
             name: "Lightbox",
             targets: ["Lightbox"]),
     ],
-    dependencies: [
-      .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.1.0")
-    ],
+    dependencies: [],
     targets: [
         .target(
             name: "Lightbox",
-            dependencies: ["SDWebImage"],
+            dependencies: [],
             path: "Source"
             )
     ],

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -1,7 +1,6 @@
 import UIKit
 import AVKit
 import AVFoundation
-import SDWebImage
 
 public class LightboxConfig {
   /// Whether to show status bar while Lightbox is presented
@@ -18,13 +17,7 @@ public class LightboxConfig {
   }
 
   /// How to load image onto SDAnimatedImageView
-  public static var loadImage: (SDAnimatedImageView, URL, ((UIImage?) -> Void)?) -> Void = { (imageView, imageURL, completion) in
-
-    // Use SDWebImage by default
-    imageView.sd_setImage(with: imageURL) { image, error, _ , _ in
-      completion?(image)
-    }
-  }
+  public static var loadImage: ((UIImageView, URL, ((UIImage?) -> Void)?) -> Void)?
 
   /// Indicator is used to show while image is being fetched
   public static var makeLoadingIndicator: () -> UIView = {

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SDWebImage
 
 public protocol LightboxControllerPageDelegate: AnyObject {
 
@@ -45,8 +44,8 @@ open class LightboxController: UIViewController {
     return view
   }()
 
-  lazy var backgroundView: SDAnimatedImageView = {
-    let view = SDAnimatedImageView()
+  lazy var backgroundView: UIImageView = {
+    let view = UIImageView()
     view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
     return view
@@ -384,7 +383,7 @@ extension LightboxController: UIScrollViewDelegate {
 
 extension LightboxController: PageViewDelegate {
 
-  func remoteImageDidLoad(_ image: UIImage?, imageView: SDAnimatedImageView) {
+  func remoteImageDidLoad(_ image: UIImage?, imageView: UIImageView) {
     guard let image = image, dynamicBackground else {
       return
     }

--- a/Source/LightboxImage.swift
+++ b/Source/LightboxImage.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SDWebImage
 
 open class LightboxImage {
 
@@ -33,12 +32,19 @@ open class LightboxImage {
     self.videoURL = videoURL
   }
 
-  open func addImageTo(_ imageView: SDAnimatedImageView, completion: ((UIImage?) -> Void)? = nil) {
+  open func addImageTo(_ imageView: UIImageView, completion: ((UIImage?) -> Void)? = nil) {
     if let image = image {
       imageView.image = image
       completion?(image)
     } else if let imageURL = imageURL {
-      LightboxConfig.loadImage(imageView, imageURL, completion)
+      guard let loadImage = LightboxConfig.loadImage else {
+        print("Lightbox: To use `imageURL`, you must use `LightboxConfig.loadImage`.")
+        imageView.image = nil
+        completion?(nil)
+        return
+      }
+
+      loadImage(imageView, imageURL, completion)
     } else if let imageClosure = imageClosure {
       let img = imageClosure()
       imageView.image = img

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -1,18 +1,17 @@
 import UIKit
-import SDWebImage
 
 protocol PageViewDelegate: AnyObject {
 
   func pageViewDidZoom(_ pageView: PageView)
-  func remoteImageDidLoad(_ image: UIImage?, imageView: SDAnimatedImageView)
+  func remoteImageDidLoad(_ image: UIImage?, imageView: UIImageView)
   func pageView(_ pageView: PageView, didTouchPlayButton videoURL: URL)
   func pageViewDidTouch(_ pageView: PageView)
 }
 
 class PageView: UIScrollView {
 
-  lazy var imageView: SDAnimatedImageView = {
-    let imageView = SDAnimatedImageView()
+  lazy var imageView: UIImageView = {
+    let imageView = UIImageView()
     imageView.contentMode = .scaleAspectFit
     imageView.clipsToBounds = true
     imageView.isUserInteractionEnabled = true

--- a/iOSDemo/ViewController.swift
+++ b/iOSDemo/ViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Lightbox
+import SDWebImage
 
 class ViewController: UIViewController {
   
@@ -23,6 +24,11 @@ class ViewController: UIViewController {
     view.addSubview(showButton)
     title = "Lightbox"
     LightboxConfig.preload = 2
+    LightboxConfig.loadImage = { imageView, url, completion in
+      imageView.sd_setImage(with: url) { image, _, _ , _ in
+        completion?(image)
+      }
+    }
   }
   
   // MARK: - Action methods


### PR DESCRIPTION
fix #284 .

Since it is undesirable to depend on a specific image library, removed `SDWebImage` dependency.  
If developers use `LightboxImage(imageURL:)`, they must also implement `LightboxConfig.loadImage` at the same time.  
The same behavior as before can be achieved by using any image library in `LightboxConfig.loadImage`.