### PR TITLE
Add tap delegate for tap/double tap detection

### DIFF
--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -16,6 +16,13 @@ public protocol LightboxControllerTouchDelegate: AnyObject {
   func lightboxController(_ controller: LightboxController, didTouch image: LightboxImage, at index: Int)
 }
 
+public protocol LightboxControllerTapDelegate: AnyObject {
+    
+  func lightboxController(_ controller: LightboxController, didTap image: LightboxImage, at index: Int)
+    
+  func lightboxController(_ controller: LightboxController, didDoubleTap image: LightboxImage, at index: Int)
+}
+
 public protocol LightboxControllerDeleteDelegate: AnyObject {
 
   func lightboxController(_ controller: LightboxController, willDeleteAt index: Int)
@@ -145,6 +152,7 @@ open class LightboxController: UIViewController {
   open weak var pageDelegate: LightboxControllerPageDelegate?
   open weak var dismissalDelegate: LightboxControllerDismissalDelegate?
   open weak var imageTouchDelegate: LightboxControllerTouchDelegate?
+  open weak var imageTapDelegate: LightboxControllerTapDelegate?
   open weak var imageDeleteDelegate: LightboxControllerDeleteDelegate?
   open internal(set) var presented = false
   open fileprivate(set) var seen = false
@@ -419,6 +427,14 @@ extension LightboxController: PageViewDelegate {
 
     let visible = (headerView.alpha == 1.0)
     toggleControls(pageView: pageView, visible: !visible)
+  }
+    
+  func pageViewDidTap(_ pageView: PageView) {
+    imageTapDelegate?.lightboxController(self, didTap: images[currentPage], at: currentPage)
+  }
+    
+  func pageViewDidDoubleTap(_ pageView: PageView) {
+    imageTapDelegate?.lightboxController(self, didDoubleTap: images[currentPage], at: currentPage)
   }
 }
 

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -7,7 +7,8 @@ protocol PageViewDelegate: AnyObject {
   func remoteImageDidLoad(_ image: UIImage?, imageView: SDAnimatedImageView)
   func pageView(_ pageView: PageView, didTouchPlayButton videoURL: URL)
   func pageViewDidTouch(_ pageView: PageView)
-}
+  func pageViewDidTap(_ pageView: PageView)
+  func pageViewDidDoubleTap(_ pageView: PageView)}
 
 class PageView: UIScrollView {
 
@@ -147,10 +148,12 @@ class PageView: UIScrollView {
     let rectToZoomTo = CGRect(x: x, y: y, width: width, height: height)
 
     zoom(to: rectToZoomTo, animated: true)
+    pageViewDelegate?.pageViewDidDoubleTap(self)
   }
 
   @objc func viewTapped(_ recognizer: UITapGestureRecognizer) {
     pageViewDelegate?.pageViewDidTouch(self)
+    pageViewDelegate?.pageViewDidTap(self)
   }
 
   // MARK: - Layout


### PR DESCRIPTION
A reliable tap event helps users hide/unhide navigation bar or toolbars to give a full unobstructed view of the image.