### PR TITLE
fix: 'class' keyword to define a class-constrained protocol is deprecated

### DIFF
--- a/Source/Library/LayoutConfigurable.swift
+++ b/Source/Library/LayoutConfigurable.swift
@@ -1,4 +1,4 @@
-protocol LayoutConfigurable: class {
+protocol LayoutConfigurable: AnyObject {
 
   func configureLayout()
 }

--- a/Source/Views/FooterView.swift
+++ b/Source/Views/FooterView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol FooterViewDelegate: class {
+public protocol FooterViewDelegate: AnyObject {
 
   func footerView(_ footerView: FooterView, didExpand expanded: Bool)
 }

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol HeaderViewDelegate: class {
+protocol HeaderViewDelegate: AnyObject {
   func headerView(_ headerView: HeaderView, didPressDeleteButton deleteButton: UIButton)
   func headerView(_ headerView: HeaderView, didPressCloseButton closeButton: UIButton)
 }

--- a/Source/Views/InfoLabel.swift
+++ b/Source/Views/InfoLabel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol InfoLabelDelegate: class {
+public protocol InfoLabelDelegate: AnyObject {
 
   func infoLabel(_ infoLabel: InfoLabel, didExpand expanded: Bool)
 }


### PR DESCRIPTION
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
- Source/Library/LayoutConfigurable.swift:1:30
- Source/Views/FooterView.swift:3:37
- Source/Views/HeaderView.swift:3:30
- Source/Views/InfoLabel.swift:3:36
