### PR TITLE
Fix build error for MainActor isolation.

### DIFF
--- a/Source/Library/LayoutConfigurable.swift
+++ b/Source/Library/LayoutConfigurable.swift
@@ -1,4 +1,4 @@
 protocol LayoutConfigurable: AnyObject {
-
+  @MainActor
   func configureLayout()
 }

--- a/Source/LightboxConfig.swift
+++ b/Source/LightboxConfig.swift
@@ -9,6 +9,7 @@ public class LightboxConfig {
   public static var imageBackgroundColor = UIColor.black
 
   /// Provide a closure to handle selected video
+  @MainActor
   public static var handleVideo: (_ from: UIViewController, _ videoURL: URL) -> Void = { from, videoURL in
     let videoController = AVPlayerViewController()
     videoController.player = AVPlayer(url: videoURL)
@@ -22,6 +23,7 @@ public class LightboxConfig {
   public static var loadImage: ((UIImageView, URL, ((UIImage?) -> Void)?) -> Void)?
 
   /// Indicator is used to show while image is being fetched
+  @MainActor
   public static var makeLoadingIndicator: () -> UIView = {
     return LoadingIndicator()
   }

--- a/Source/LightboxController.swift
+++ b/Source/LightboxController.swift
@@ -1,29 +1,29 @@
 import UIKit
 
 public protocol LightboxControllerPageDelegate: AnyObject {
-
+  @MainActor
   func lightboxController(_ controller: LightboxController, didMoveToPage page: Int)
 }
 
 public protocol LightboxControllerDismissalDelegate: AnyObject {
-
+  @MainActor
   func lightboxControllerWillDismiss(_ controller: LightboxController)
 }
 
 public protocol LightboxControllerTouchDelegate: AnyObject {
-
+  @MainActor
   func lightboxController(_ controller: LightboxController, didTouch image: LightboxImage, at index: Int)
 }
 
 public protocol LightboxControllerTapDelegate: AnyObject {
-    
+  @MainActor
   func lightboxController(_ controller: LightboxController, didTap image: LightboxImage, at index: Int)
-    
+  @MainActor
   func lightboxController(_ controller: LightboxController, didDoubleTap image: LightboxImage, at index: Int)
 }
 
 public protocol LightboxControllerDeleteDelegate: AnyObject {
-
+  @MainActor
   func lightboxController(_ controller: LightboxController, willDeleteAt index: Int)
 }
 

--- a/Source/Views/FooterView.swift
+++ b/Source/Views/FooterView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public protocol FooterViewDelegate: AnyObject {
-
+  @MainActor
   func footerView(_ footerView: FooterView, didExpand expanded: Bool)
 }
 

--- a/Source/Views/HeaderView.swift
+++ b/Source/Views/HeaderView.swift
@@ -1,7 +1,9 @@
 import UIKit
 
 protocol HeaderViewDelegate: AnyObject {
+  @MainActor
   func headerView(_ headerView: HeaderView, didPressDeleteButton deleteButton: UIButton)
+  @MainActor
   func headerView(_ headerView: HeaderView, didPressCloseButton closeButton: UIButton)
 }
 

--- a/Source/Views/InfoLabel.swift
+++ b/Source/Views/InfoLabel.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public protocol InfoLabelDelegate: AnyObject {
-
+  @MainActor
   func infoLabel(_ infoLabel: InfoLabel, didExpand expanded: Bool)
 }
 

--- a/Source/Views/PageView.swift
+++ b/Source/Views/PageView.swift
@@ -1,12 +1,17 @@
 import UIKit
 
 protocol PageViewDelegate: AnyObject {
-
+  @MainActor
   func pageViewDidZoom(_ pageView: PageView)
+  @MainActor
   func remoteImageDidLoad(_ image: UIImage?, imageView: UIImageView)
+  @MainActor
   func pageView(_ pageView: PageView, didTouchPlayButton videoURL: URL)
+  @MainActor
   func pageViewDidTouch(_ pageView: PageView)
+  @MainActor
   func pageViewDidTap(_ pageView: PageView)
+  @MainActor
   func pageViewDidDoubleTap(_ pageView: PageView)}
 
 class PageView: UIScrollView {


### PR DESCRIPTION
I have fixed the following build error.  
Confirmed with Xcode 16 beta 4 and Swift 6.  
`Main actor-isolated instance method '...' cannot be used to satisfy nonisolated protocol requirement`.